### PR TITLE
[#7] fix: remove unused state setter, unify tailwind colors, remove u…

### DIFF
--- a/src/components/DateBadge/DateBadge.tsx
+++ b/src/components/DateBadge/DateBadge.tsx
@@ -13,9 +13,7 @@ export default function DateBadge({
       <p className="w-7.5 px-2 flex">
         <img src={calendarIconUrl} alt="calendar" className="size-full" />
       </p>
-      <p className="text-gray-300 text-neutral-400 text-sm font-normal font-['Inter']">
-        {date}
-      </p>
+      <p className="text-gray-300 text-sm font-normal font-['Inter']">{date}</p>
     </div>
   )
 }

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -2,7 +2,7 @@ import HomeNav from './HomeNav'
 import { Calendar28 } from './PickerWithInput'
 import Category from './Category'
 import CardList from './CardList'
-import dayjs from 'dayjs'
+// import dayjs from 'dayjs'
 import { useState } from 'react'
 
 export default function Home() {
@@ -25,7 +25,8 @@ export default function Home() {
       date: { start: '2025년 10월 5일', end: '2025년 10월 12일' },
     },
   ]
-  const [filterDate, setFilterDate] = useState({
+
+  const [filterDate] = useState({
     start: new Date(),
     end: new Date(),
   })

--- a/src/pages/Home/HomeNav.tsx
+++ b/src/pages/Home/HomeNav.tsx
@@ -1,5 +1,5 @@
 import { DateBadge } from '@/components'
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 interface HomeNavProps {
   images: string[]
@@ -114,11 +114,11 @@ export default function HomeNav({ images, event, className }: HomeNavProps) {
               </h2>
               <div className="flex justify-start items-center gap-1">
                 <DateBadge date={currentEvent.date.start} />
-                <span className="text-gray-300 text-neutral-400 text-sm font-normal font-['Inter']">
+                <span className="text-gray-300  text-sm font-normal font-['Inter']">
                   부터
                 </span>
                 <DateBadge date={currentEvent.date.end} />
-                <span className="text-gray-300 text-neutral-400 text-sm font-normal font-['Inter']">
+                <span className="text-gray-300  text-sm font-normal font-['Inter']">
                   까지
                 </span>
               </div>


### PR DESCRIPTION
[#7] fix: 미사용 setter 제거, tailwind 색상 통일, React 기본 임포트 제거

- TS/ESLint 경고 해소를 위해 사용되지 않는 setFilterDate setter 제거
- 동일 요소에 중복 적용된 Tailwind 색상 클래스(text-gray-300 / text-neutral-400) 중 하나로 통일
- react-jsx 환경에서 불필요한 React 기본 임포트 제거, 필요한 훅(useState, useEffect, useRef)만 개별 임포트
